### PR TITLE
Distribute scripts with package on hex.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Tracer.Mixfile do
   end
 
   defp package do
-    [files: ~w(lib test mix.exs README.md LICENSE.md VERSION.md),
+    [files: ~w(lib test scripts mix.exs README.md LICENSE.md VERSION.md),
      maintainers: ["Gabi Zuniga"],
      licenses: ["MIT"],
      links: %{"GitHub" => "https://github.com/gabiz/tracer"}]


### PR DESCRIPTION
The "scripts" directory is currently not published with the tracer package on hex.pm.